### PR TITLE
Fetch a compatible chromedriver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
             && sudo mv chromedriver /usr/local/bin/chromedriver \
             && sudo chmod +x /usr/local/bin/chromedriver \
             && chromedriver --version \
-            && which chromedriver \
-            && CHROMEDRIVER_FILEPATH=/usr/local/bin/chromedriver
 
       - name: Use Node.js 12.13.0
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,27 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Fetch compatible chromedriver
+        run: |
+          CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1) \
+            && CHROMEDRIVER_RELEASE=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) \
+            && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
+            && cd /tmp \
+            && unzip chromedriver_linux64.zip \
+            && rm -rf chromedriver_linux64.zip \
+            && sudo mv chromedriver /usr/local/bin/chromedriver \
+            && sudo chmod +x /usr/local/bin/chromedriver \
+            && chromedriver --version \
+            && which chromedriver \
+            && CHROMEDRIVER_FILEPATH=/usr/local/bin/chromedriver
+
       - name: Use Node.js 12.13.0
         uses: actions/setup-node@v1
         with:
           node-version: 12.13.0
 
       - name: Install
-        run: npm ci
+        run: CHROMEDRIVER_FILEPATH=/usr/local/bin/chromedriver npm ci
 
       - name: Build
         run: docker build --tag ${TEST_DOCKER_IMAGE} .


### PR DESCRIPTION
Fetch the chromedriver which matches the version of Chrome installed on CI, to prevent "This version of ChromeDriver only supports Chrome version xx" errors causing build failures.

Fix courtesy of @kalekseev (via https://github.com/actions/virtual-environments/issues/9#issuecomment-555949137)